### PR TITLE
NameError k_disc not defined is resolved

### DIFF
--- a/adda.py
+++ b/adda.py
@@ -103,8 +103,8 @@ def main(args):
                 loss.backward()
                 target_optim.step()
 
-        mean_loss = total_loss / (args.iterations*k_disc)
-        mean_accuracy = total_accuracy / (args.iterations*k_disc)
+        mean_loss = total_loss / (args.iterations*args.k_disc)
+        mean_accuracy = total_accuracy / (args.iterations*args.k_disc)
         tqdm.write(f'EPOCH {epoch:03d}: discriminator_loss={mean_loss:.4f}, '
                    f'discriminator_accuracy={mean_accuracy:.4f}')
 


### PR DESCRIPTION
Variable `k_disc` was not defined by itself, because it is a field of object `args`. However,  `k_disc` was forgotten to be associated with `args`. This issue is fixed here. 